### PR TITLE
Update torch pin for Python 3.12 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pyyaml==6.0.1
 typer==0.12.3
 pytest==7.4.4
 tqdm==4.66.2
-torch==2.1.0
-transformers==4.36.0
-sentence-transformers==2.3.0
+torch==2.3.1
+transformers==4.38.0
+sentence-transformers==2.6.1
 huggingface-hub==0.20.0


### PR DESCRIPTION
## Summary
- bump the torch dependency to 2.3.1 so Python 3.12 receives a supported wheel
- refresh transformers and sentence-transformers pins to match the newer torch release

## Testing
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68d15e474f3c83219668c02b44490b08